### PR TITLE
Add read_measured_values_as_integers_with_raw_parameters Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`added`] Get serial command to SVM40 driver
+ * [`added`] Read Measured Values As Integers With Raw Parameters command to SVM40 driver 
 
 ## [0.1.0] - 2020-09-01
 

--- a/svm40/svm40.c
+++ b/svm40/svm40.c
@@ -94,6 +94,36 @@ int16_t svm40_read_measured_values_as_integers(int16_t* voc_index,
     return NO_ERROR;
 }
 
+int16_t svm40_read_measured_values_as_integers_with_raw_params(
+    int16_t* voc_index, int16_t* relative_humidity, int16_t* temperature,
+    uint16_t* voc_ticks_raw, int16_t* uncompensated_relative_humidity,
+    int16_t* uncompensated_temperature) {
+    int16_t error;
+    uint16_t buffer[6];
+
+    error = sensirion_i2c_write_cmd(
+        SVM40_I2C_ADDRESS,
+        SVM40_CMD_READ_MEASURED_VALUES_AS_INTEGERS_WITH_RAW_PARAMETERS);
+    if (error) {
+        return error;
+    }
+
+    error = sensirion_i2c_read_words(SVM40_I2C_ADDRESS, buffer,
+                                     SENSIRION_NUM_WORDS(buffer));
+    if (error) {
+        return error;
+    }
+
+    *voc_index = (int16_t)buffer[0];
+    *relative_humidity = (int16_t)buffer[1];
+    *temperature = (int16_t)buffer[2];
+    *voc_ticks_raw = buffer[3];
+    *uncompensated_relative_humidity = (int16_t)buffer[4];
+    *uncompensated_temperature = (int16_t)buffer[5];
+
+    return NO_ERROR;
+}
+
 int16_t
 svm40_get_version(struct svm40_version_information* version_information) {
     int16_t error;

--- a/svm40/svm40.h
+++ b/svm40/svm40.h
@@ -137,6 +137,39 @@ int16_t svm40_read_measured_values_as_integers(int16_t* voc_index,
                                                int16_t* temperature);
 
 /**
+ * Returns the new measurement results as integers along with the raw voc
+ * ticks and uncompensated RH/T values.
+ *
+ * The firmware updates the measurement values every second. Polling data
+ * faster will return the same values. The first measurement is available one
+ * second after the start measurement command is issued. Any readout prior to
+ * this will return zero initialized values.
+ *
+ * @note Only available in measurement mode.
+ * @param   voc_index                       VOC algorithm output
+ *                                          with a scaling value of 10.
+ * @param   relative_humidity               Compensated ambient
+ *                                          humidity in %RH with a scaling
+ *                                          factor of 100.
+ * @param   temperature                     Compensated ambient temperature
+ *                                          in degree celsius with a scaling
+ *                                          factor of 200.
+ * @param   voc_ticks_raw                   Raw VOC output ticks as
+ *                                          read from the SGP sensor.
+ * @param   uncompensated_relative_humidity Uncompensated raw humidity in
+ *                                          %RH as read from the SHT40 with a
+ *                                          scaling factor of 100.
+ * @param   uncompensated_temperature       Uncompensated raw temperature in
+ *                                          degrees celsius as read from the
+ *                                          SHT40 with a scaling of 200.
+ * @return  NO_ERROR on success, an error code otherwise
+ */
+int16_t svm40_read_measured_values_as_integers_with_raw_params(
+    int16_t* voc_index, int16_t* relative_humidity, int16_t* temperature,
+    uint16_t* voc_ticks_raw, int16_t* uncompensated_relative_humidity_raw,
+    int16_t* uncompensated_temperature);
+
+/**
  * Return the driver version
  *
  * @return  Driver version string


### PR DESCRIPTION
- Add and implement function
  read_measured_values_as_integers_with_raw_parameters to svm40.h
  and svm40.c file.
- Update Changelog.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
